### PR TITLE
Use a safe query in PageTemplateManager to load pages.

### DIFF
--- a/src/WebPages/PageTemplateManager.cs
+++ b/src/WebPages/PageTemplateManager.cs
@@ -311,8 +311,7 @@ namespace SenseNet.Portal
         {
             if (SearchManager.ContentQueryIsAllowed)
             {
-                var cql = $"+TypeIs:{typeof(Page).Name} + PageTemplateNode:{_pageTemplate.Id}";
-                return ContentQuery.Query(cql, QuerySettings.AdminSettings).Nodes;
+                return ContentQuery.Query(SafeQueries.LoadPagesForTemplate, QuerySettings.AdminSettings, _pageTemplate.Id).Nodes;
             }
             // we need to execute a direct database query because the outer engine is disabled
             return NodeQuery.QueryNodesByReferenceAndType("PageTemplateNode", this.PageTemplateNode.Id, ActiveSchema.NodeTypes[typeof(Page).Name], false).Nodes;

--- a/src/WebPages/SafeQueries.cs
+++ b/src/WebPages/SafeQueries.cs
@@ -21,5 +21,8 @@ namespace SenseNet.Portal
 
         /// <summary>Returns with the following query: "+TypeIs:@0 +SmartUrl:@1 -Path:@2"</summary>
         public static string SmartUrlCollision { get; } = "+TypeIs:@0 +SmartUrl:@1 -Path:@2";
+
+        /// <summary>Returns the following query: "+TypeIs:Page +PageTemplateNode:@0"</summary>
+        public static string LoadPagesForTemplate { get; } = "+TypeIs:Page +PageTemplateNode:@0";
     }
 }


### PR DESCRIPTION
This fix was necessary because during patching (sn6-sn7) a text query was executed in admin mode (from an snadmin step) and it was not registered among safe queries.